### PR TITLE
 JsonlParser: improve truncating the file when poping and pushing items 

### DIFF
--- a/src/JsonlParser.php
+++ b/src/JsonlParser.php
@@ -65,9 +65,10 @@ class JsonlParser implements \Countable
 
         $buffer = strrev($buffer);
 
-        // truncate the stream and remove the trailing newline
+        // truncate the stream
+        // remove the trailing newline if the stream is now empty
         $pos = ftell($this->stream);
-        ftruncate($this->stream, $pos < 1 ? 0 : $pos-1);
+        ftruncate($this->stream, $pos <= strlen(self::LINES_SEPARATOR) ? 0 : $pos);
 
         return json_decode($buffer, associative: true);
     }

--- a/src/JsonlParser.php
+++ b/src/JsonlParser.php
@@ -13,6 +13,15 @@ class JsonlParser implements \Countable
     {
     }
 
+    /**
+     * Initialize the parser from the given file.
+     */
+    public static function fromFile(string $filename, string $mode = 'a+t'): self
+    {
+        $stream = fopen($filename, $mode);
+        return new self($stream);
+    }
+
     public function push(array|string $item): void
     {
         $encoded = json_encode($item);

--- a/src/JsonlParser.php
+++ b/src/JsonlParser.php
@@ -104,4 +104,12 @@ class JsonlParser implements \Countable
 
         return $count;
     }
+
+    /**
+     * Checks if there are no items in the stream.
+     */
+    public function empty(): bool
+    {
+        return count($this) === 0;
+    }
 }

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -135,9 +135,12 @@ class JsonParserTest extends BaseTestCase
         // TODO: introduce a helper JsonlParser::fromFile()
         $parser = new JsonlParser($stream);
         $this->assertCount(0, $parser);
+        $this->assertTrue($parser->empty());
+
         $parser->push(self::ITEM_ONE);
         $parser->push(self::ITEM_TWO);
         $this->assertCount(2, $parser);
+        $this->assertFalse($parser->empty());
 
         // now get one and push the next item
         $this->assertSame(self::ITEM_TWO, $parser->pop());
@@ -157,6 +160,7 @@ class JsonParserTest extends BaseTestCase
         $parser->pop();
         $parser->pop();
         $this->assertCount(0, $parser);
+        $this->assertTrue($parser->empty());
         $this->assertStringEqualsFile(
             expectedFile: $tmpFilename,
             actualString: ''

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -127,13 +127,11 @@ class JsonParserTest extends BaseTestCase
         fclose($stream); // this removes the file
     }
 
-    public function testFileSyncing(): void
+    public function testFromFile(): void
     {
         $tmpFilename = tempnam(directory: sys_get_temp_dir(), prefix: 'jsonld');
-        $stream = fopen($tmpFilename, 'a+t');
 
-        // TODO: introduce a helper JsonlParser::fromFile()
-        $parser = new JsonlParser($stream);
+        $parser = JsonlParser::fromFile($tmpFilename);
         $this->assertCount(0, $parser);
         $this->assertTrue($parser->empty());
 
@@ -166,7 +164,6 @@ class JsonParserTest extends BaseTestCase
             actualString: ''
         );
 
-        fclose($stream);
         unlink($tmpFilename);
     }
 }


### PR DESCRIPTION
Introduce the `empty()` and `JsonlParser::fromFile` helpers.